### PR TITLE
Fix config bool parsing/blank screenshots being saved 

### DIFF
--- a/imgruber/Config.cs
+++ b/imgruber/Config.cs
@@ -16,18 +16,18 @@ namespace imgruber
 
         public void LoadConfigurations()
         {
-            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Imgruber\Config", true);
+            // If key is null, create it.
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Imgruber\Config", true) ??
+                              Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Imgruber\Config");
 
-            if (key == null)
-            {
-                key = Registry.LocalMachine.CreateSubKey(@"SOFTWARE\Imgruber\Config");
-            }
-
-            useCtrlBOX.Checked = bool.Parse((string) key.GetValue("hotkeyCTRL", false));
-            useAltBOX.Checked = bool.Parse((string) key.GetValue("hotkeyALT", false));
+            // Originally these were cast as strings and parsed as bools, but
+            // they are actually stored as bools in the reg. 
+            
+            useCtrlBOX.Checked = (bool)key.GetValue("hotkeyCTRL", false);
+            useAltBOX.Checked = (bool)key.GetValue("hotkeyALT", false);
             HotkeyCOMBO.SelectedIndex = (int) key.GetValue("hotkeyIndex", 0);
             LinkCodeCOMBO.SelectedIndex = (int) key.GetValue("linkCodeIndex", 0);
-            TweetThisCB.Checked = bool.Parse((string) key.GetValue("autoTweet", false));
+            TweetThisCB.Checked = (bool)key.GetValue("autoTweet", false);
             TweetPrependTB.Text = (string) key.GetValue("prependText", "");
         }
 

--- a/imgruber/Screenshot.cs
+++ b/imgruber/Screenshot.cs
@@ -62,6 +62,13 @@ namespace imgruber
         private void ss_MouseUp(object sender, MouseEventArgs e)
         {
             _ssField.Hide();
+
+            // If the user just clicks on the screen, instead of drawing a square.
+            // It would throw creating a new bitmap. In this case, just ignore and leave.
+            if (_rect.Width <= 0 || _rect.Height <= 0)
+            {
+                return;
+            }
             var bmp = new Bitmap(_rect.Width, _rect.Height);
             using (Graphics g = Graphics.FromImage(bmp))
             {


### PR DESCRIPTION
This should fix two small bugs. The first one is that, originally, some of the settings in the registry file were being parsed as bools from strings. In fact, that are stored as bools already, so it would just throw if you started the app. I also simplified the creation of the key by using ?? syntax. 

Second is if the user just clicks when making a screenshot. This would create a _rect of 0x0, which you can't make a bitmap. This would cause it to throw and crash. I just put in a simple check for if the _rect is 0 or less, just return. The user probably was not trying to make anything anyway at that point.
